### PR TITLE
use correct precedence with `return $x || die`

### DIFF
--- a/lib/App/GitGot/Repo/Git.pm
+++ b/lib/App/GitGot/Repo/Git.pm
@@ -46,7 +46,7 @@ sub _build__wrapper {
   }
   else {
     return Git::Wrapper->new( $self->path )
-      or die "Can't make Git::Wrapper";
+      || die "Can't make Git::Wrapper";
   }
 }
 


### PR DESCRIPTION
The code used `return $x or die`, which means that `$x` is always
returned because `return` is higher precedence than `or`.

This was spotted by a new warning in perl 5.19.
