### PR TITLE
add session (-s) switch to `got mux`

### DIFF
--- a/lib/App/GitGot/Command/mux.pm
+++ b/lib/App/GitGot/Command/mux.pm
@@ -5,6 +5,14 @@ use Mouse;
 extends 'App::GitGot::Command';
 use 5.010;
 
+has session => (
+    traits        => [qw(Getopt)],
+    isa           => 'Bool',
+    is            => 'ro',
+    cmd_aliases   => 's',
+    documentation => 'use tmux-sessions',
+);
+
 sub command_names { qw/ mux tmux / }
 
 sub _execute {
@@ -17,17 +25,30 @@ sub _execute {
 
   my( $repo ) = $self->active_repos;
 
+  my $target = $self->session ? 'session' : 'window';
+
   # is it already opened?
   my %windows = reverse map { /^(\d+):::(\S+)/ }
-    split "\n", `tmux list-windows -F"#I:::#W"`;
+    split "\n", `tmux list-$target -F"#I:::#W"`;
 
   if( my $window = $windows{$repo->name} ) {
-      exec 'tmux', 'select-window', '-t' => $window;
+    if ($self->session) {
+        exec 'tmux', 'switch-client', '-t' => $window;
+    } else {
+        exec 'tmux', 'select-window', '-t' => $window;
+    }
   }
 
   chdir $repo->path;
 
-  exec 'tmux', 'new-window', '-n', $repo->name;
+  if ($self->session) {
+    delete local $ENV{TMUX};
+    system 'tmux', 'new-session', '-d', '-s', $repo->name;
+    exec 'tmux', 'switch-client', '-t' => $repo->name;
+  } else {
+    exec 'tmux', 'new-window', '-n', $repo->name;
+  }
+
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Add a switch to the mux command that enables creating sessions rather than
windows when interacting with tmux.
