### PR TITLE
Don't load Net::GitHub unless we need it

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,6 +21,7 @@ exclude_filename = dist.ini
 Git::Wrapper = 0.014
 MouseX::App::Cmd = 0
 MouseX::NativeTraits = 0
+Net::Github = 0
 Term::ReadLine::Perl = 0
 [Prereqs / RuntimeRecommends]
 IO::Page = 0

--- a/lib/App/GitGot/Command/fork.pm
+++ b/lib/App/GitGot/Command/fork.pm
@@ -9,7 +9,7 @@ use autodie;
 use App::GitGot::Repo::Git;
 use Cwd;
 use File::Slurp::Tiny 'read_lines';
-use Net::GitHub;
+use Class::Load;
 
 has 'noclone' => (
   is          => 'rw',
@@ -28,6 +28,7 @@ sub _execute {
 
   my %gh_args = _parse_github_identity();
 
+  Class::Load::load_class('Net::GitHub');
   my $resp = Net::GitHub->new( %gh_args )->repos->create_fork( $owner , $repo_name );
 
   my $new_repo = App::GitGot::Repo::Git->new({ entry => {


### PR DESCRIPTION
Loading this conditionally shaves off ~0.3sec runtime on my laptop, running a
plain 'git got'.
