### PR TITLE
do terrible things to 'got add'

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -30,6 +30,7 @@ IO::Prompt::Simple=0
 File::chdir=0
 [Prereqs / RuntimeRecommends]
 IO::Page = 0
+Path::Iterator::Rule=0
 [Prereqs / RuntimeSuggests]
 Net::GitHub = 0
 [GithubMeta]

--- a/dist.ini
+++ b/dist.ini
@@ -23,6 +23,11 @@ Git::Wrapper = 0.014
 MouseX::App::Cmd = 0
 MouseX::NativeTraits = 0
 Term::ReadLine::Perl = 0
+Path::Tiny=0
+List::AllUtils=0
+PerlX::Maybe=0
+IO::Prompt::Simple=0
+File::chdir=0
 [Prereqs / RuntimeRecommends]
 IO::Page = 0
 [Prereqs / RuntimeSuggests]

--- a/lib/App/GitGot/Command/add.pm
+++ b/lib/App/GitGot/Command/add.pm
@@ -112,3 +112,12 @@ sub _init_for_git {
 
 __PACKAGE__->meta->make_immutable;
 1;
+
+__END__
+
+=head1 SYNOPSIS
+
+    # add repository of current directory
+    $ got add 
+
+=cut


### PR DESCRIPTION
* Allow to pass more than one directory as arguments.

* add '--recursive', to hunt down git repos under a main directory.

* make '--tag X' set the default tag(s) to X

* If there's only one remote, don't ask, use that one.

* Instead of asking the user to type the remote uri, give the choice between the remote name/url pairs.
